### PR TITLE
Compatibility with Redmine 2.5.1

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@ class Notification < ActiveRecord::Base
     end
     true
   rescue NameError, ActiveRecord::RecordNotFound
-    Rails.logger.error "Plugin redmine_notified: unable to find an object for message_id=#{message_id}"
+    Rails.logger.error "Plugin redmine_notified: unable to find an object for message_id=#{message_id}" unless Rails.env.test?
     self.notificable = nil
     true
   end


### PR DESCRIPTION
Redmine 2.5 adds new tests ; especially this one

```
Mailer_test.rb => "test_should_log_delivery_errors_when_raise_delivery_errors_is_false"
```

which is broken by the redmine_notified plugin.

I wonder what's the best way to avoid breaking core tests.
Should we just not throw the custom error if Rails.env is test as I suggest in this pull request ?
Or should we initialize message_id if it's nil and Rails.env is test ?

Any better idea ?
